### PR TITLE
Replace erroneous stackvar_lock w/correct one

### DIFF
--- a/binja_frontend.py
+++ b/binja_frontend.py
@@ -221,7 +221,7 @@ def onmsg(bv, key, data, replay):
         state.structs_lock.release()
         log_info('revsync: <%s> %s %s' % (user, cmd, struct_name))
     elif cmd == 'struc_deleted':
-        state.stackvar_lock.acquire()
+        state.structs_lock.acquire()
         struct_name = data['struc_name'].encode('ascii', 'ignore')
         struct = bv.get_type_by_name(struct_name)
         # make sure the type is defined first


### PR DESCRIPTION
Looks like the stack_var lock was erroneously being picked up where I think it was supposed to be structs_lock.