### PR TITLE
Fixed issue with IDA 7.6 API  (IDBHooks.renamed)

### DIFF
--- a/ida_frontend.py
+++ b/ida_frontend.py
@@ -129,8 +129,12 @@ class IDPHooks(IDP_Hooks):
         return IDP_Hooks.auto_empty_finally(self)
 
 class IDBHooks(IDB_Hooks):
-    def renamed(self, ea, new_name, local_name):
+    def renamed(self, ea, new_name, local_name, old_name=None):
         on_renamed(ea, new_name, local_name)
+
+        if (idaapi.IDA_SDK_VERSION >= 760):
+            return IDB_Hooks.renamed(self, ea, new_name, local_name, old_name)
+
         return IDB_Hooks.renamed(self, ea, new_name, local_name)
 
     def auto_empty_finally(self):


### PR DESCRIPTION
This fix wasn't tested with previous versions of IDA.

Fixes the following exception:

Exception in ida_idp.IDB_Hooks dispatcher function: SWIG director method error. Error detected when calling 'IDB_Hooks.renamed'
Traceback (most recent call last):
  File "\AppData\Roaming\Hex-Rays\IDA Pro\revsync\ida_frontend.py", line 134, in renamed
    return IDB_Hooks.renamed(self, ea, new_name, local_name)
  File "C:\Program Files\IDA Pro 7.6\python\3\ida_idp.py", line 5696, in renamed
    return _ida_idp.IDB_Hooks_renamed(self, *args)
TypeError: IDB_Hooks_renamed expected 5 arguments, got 4