### PR TITLE
Fix bugs in binja frontend

### DIFF
--- a/binja_frontend.py
+++ b/binja_frontend.py
@@ -108,6 +108,14 @@ def get_syms(bv, sym_type):
     # turn our list into dict of addr => sym name
     syms_dict = dict()
     for sym in syms:
+        # Sometimes there are duplicate symbols for a given address, and the
+        # order they're returned from bv.get_symbols_of_type is
+        # nondeterministic.
+        # This created a bug where revsync would think the user renamed a ton of
+        # symbols whenever that order happened to change.
+        # This is probably slow, but I don't know what else to do about it
+        if bv.get_symbol_at(sym.address) != sym:
+            continue
         syms_dict[sym.address] = sym.name
     return syms_dict
 

--- a/binja_frontend.py
+++ b/binja_frontend.py
@@ -444,7 +444,7 @@ def watch_syms(bv, sym_type):
 
             state.data_syms = get_syms(bv, SymbolType.DataSymbol)
             state.func_syms = get_syms(bv, SymbolType.FunctionSymbol)
-            time.sleep(0.5)
+        time.sleep(0.5)
 
 def watch_cur_func(bv):
     """ Watch current function (if we're in code) for comment changes and publish diffs """


### PR DESCRIPTION
Fixed a couple bugs in the binja frontend, see commit messages for details.

The duplicate symbol fix seems to cost 2% CPU on my M1 mac, which isn't ideal, but having spurious renames is worse.

I've looked into using Binja's callbacks to move away from polling, but they don't seem to be working for me; I opened a GH issue earlier this week so the devs should get to it at some point.