### PR TITLE
binja_frontend: Correctly get file hash for BNDBs

### DIFF
--- a/binja_frontend.py
+++ b/binja_frontend.py
@@ -30,7 +30,7 @@ class State:
     def __init__(self, bv):
         self.cov = Coverage()
         self.comments = Comments()
-        self.fhash = get_fhash(bv.file.filename)
+        self.fhash = get_fhash(bv)
         self.running = True
         self.cmt_changes = {}
         self.cmt_lock = Lock()
@@ -52,9 +52,26 @@ IDLE_ASK = 250
 COLOUR_PERIOD = 20
 BB_REPORT = 50
 
-def get_fhash(fname):
-    with open(fname, 'rb') as f:
-        return hashlib.sha256(f.read()).hexdigest().upper()
+METADATA_FHASH_KEY = "revsync_fhash"
+def get_fhash(bv):
+    try:
+        return bv.query_metadata(METADATA_FHASH_KEY)
+    except KeyError:
+        # Find most-top-level BinaryView -- BN supports multiple nested layers
+        # (although in practice there are only two)
+        # We don't want the loaded view of the ELF, we want the raw, on-disk
+        # view.
+        view = bv
+        while (walk_view := view.parent_view) is not None:
+            view = walk_view
+        # This check doesn't actually catch that much, as if you save a patched
+        # binary, it resets the modification state :(
+        if any(i != ModificationStatus.Original for i in
+                view.get_modification(0, view.length)):
+            log_error("revsync: the BinaryView was patched before revsync could cache a copy of the original hash. revsync will not properly sync changes with others.")
+        fhash = hashlib.sha256(view.read(0, view.length)).hexdigest().upper()
+        bv.store_metadata(METADATA_FHASH_KEY, fhash)
+        return fhash
 
 def get_can_addr(bv, addr):
     return addr - bv.start


### PR DESCRIPTION
We were previously hashing the BNDB itself if you saved a BNDB. Now, we cache the original hash in the database, and if it's not present, we hash the contents of the top-level BinaryView, which matches the contents of the original file (modulo any patches that have been applied).

We previously discussed the pseudocode of:
1. Pull cached hash from BNDB
2. Hash `open(bv.file.original_filename).read()`
3. Hash contents of BNDB BinaryView

I'd think we should skip item 2), which is what this PR currently does. Logic is that if I've saved a DB I expect tooling to use the DB, rather than fishing around for files. But I can implement 2) if you want before merging, feel free to leave a PR comment to that effect :)

(We're already fishing around in the DB for cached metadata, so we're already in less-than-obvious-behavior territory, the question is what matches what the user means best.)

One other thing is that this PR now requires Python 3.7 (IIRC) to parse, as I'm using the walrus operator for readability. The earliest Binja release that supports Python3 supports 3.9, so that should be fine unless you're running some oddball Linux setup, of which I was probably the last ;)