### PR TITLE
Use the original filename to create the hash

### DIFF
--- a/binja_frontend.py
+++ b/binja_frontend.py
@@ -30,7 +30,7 @@ class State:
     def __init__(self, bv):
         self.cov = Coverage()
         self.comments = Comments()
-        self.fhash = get_fhash(bv.file.filename)
+        self.fhash = get_fhash(bv.file.original_filename)
         self.running = True
         self.cmt_changes = {}
         self.cmt_lock = Lock()


### PR DESCRIPTION
Use the original filename. In the case the database is loaded, the database name was used, and we don't want to calculate the hash over the database, we need the hash of the original file.